### PR TITLE
Spring Boot 2.1: Bean renamed

### DIFF
--- a/client/src/main/java/no/nav/pam/feed/taskscheduler/SchedulerConfig.java
+++ b/client/src/main/java/no/nav/pam/feed/taskscheduler/SchedulerConfig.java
@@ -1,5 +1,7 @@
 package no.nav.pam.feed.taskscheduler;
 
+import java.time.Duration;
+import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.ScheduledLockConfiguration;
@@ -9,25 +11,27 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import javax.sql.DataSource;
-import java.time.Duration;
-
 @Configuration
 @EnableScheduling
 public class SchedulerConfig {
 
     @Bean
-    public ScheduledLockConfiguration taskScheduler(LockProvider lockProvider, @Value("${feed.poolsize:10}")
-    int poolSize, @Value("${feed.duration:10}") long duration) {
+    public ScheduledLockConfiguration scheduledLockConfiguration(
+        LockProvider lockProvider,
+        @Value("${feed.poolsize:10}") int poolSize,
+        @Value("${feed.duration:10}") long duration
+    ) {
+
         return ScheduledLockConfigurationBuilder
-                .withLockProvider(lockProvider)
-                .withPoolSize(poolSize)
-                .withDefaultLockAtMostFor(Duration.ofMinutes(duration))
-                .build();
+            .withLockProvider(lockProvider)
+            .withPoolSize(poolSize)
+            .withDefaultLockAtMostFor(Duration.ofMinutes(duration))
+            .build();
+
     }
 
     @Bean
-    public LockProvider lockProvider (DataSource dataSource) {
+    public LockProvider lockProvider(DataSource dataSource) {
         return new JdbcTemplateLockProvider(dataSource);
     }
 


### PR DESCRIPTION
Got error starting pam-ad-arena when moving to Spring Boot 2.1:

The bean 'taskScheduler', defined in class path resource [org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.class], could not be registered. A bean with that name has already been defined in class path resource [no/nav/pam/feed/taskscheduler/SchedulerConfig.class] and overriding is disabled.

This pull request renames the bean (method name). Was the original intention to override?